### PR TITLE
Fix timestamp use and storage rules

### DIFF
--- a/src/AppCore.js
+++ b/src/AppCore.js
@@ -11,7 +11,8 @@ import {
   doc,
   setDoc,
   getDoc,
-  Timestamp
+  Timestamp,
+  serverTimestamp
 } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage'; // << MOVED IMPORT TO TOP
 import { XCircle, Loader2 } from 'lucide-react';
@@ -306,13 +307,13 @@ const AuthProvider = ({ children }) => {
           uid: currentUser.uid,
           email: currentUser.email ?? `anon-${currentUser.uid}@example.com`, // Fallback for anonymous
           role,
-          createdAt: Timestamp.now(),
-          lastUpdatedAt: Timestamp.now()
+          createdAt: serverTimestamp(),
+          lastUpdatedAt: serverTimestamp()
         };
         await setDoc(profileRef, newProfile);
         setUserProfile(newProfile);
       } else {
-        const update = { role, lastUpdatedAt: Timestamp.now() };
+        const update = { role, lastUpdatedAt: serverTimestamp() };
         await setDoc(profileRef, update, { merge: true });
         setUserProfile((prev) => ({ ...prev, ...update }));
       }

--- a/storage.rules
+++ b/storage.rules
@@ -38,10 +38,7 @@ service firebase.storage {
       allow read: if getUserRole() != null &&
                    ( isUserAdminForApp(appIdForFilePath) ||
                      ( isUserTraineeForApp(appIdForFilePath) &&
-                       firestore.exists(
-                         /databases/$(database)/documents/
-                         artifacts/$(appIdForFilePath)/users/$(request.auth.uid)/caseSubmissions/$(caseId)
-                       )
+                       firestore.exists(/databases/$(database)/documents/artifacts/$(appIdForFilePath)/users/$(request.auth.uid)/caseSubmissions/$(caseId))
                      )
                    );
 
@@ -60,10 +57,7 @@ service firebase.storage {
       allow read: if getUserRole() != null &&
                    ( isUserAdminForApp(appIdForFilePath) ||
                      ( isUserTraineeForApp(appIdForFilePath) &&
-                       firestore.exists(
-                         /databases/$(database)/documents/
-                         artifacts/$(appIdForFilePath)/users/$(request.auth.uid)/caseSubmissions/$(caseId)
-                       )
+                       firestore.exists(/databases/$(database)/documents/artifacts/$(appIdForFilePath)/users/$(request.auth.uid)/caseSubmissions/$(caseId))
                      )
                    );
 


### PR DESCRIPTION
## Summary
- use `serverTimestamp()` for profile creation and updates
- fix multiline paths in Firebase Storage rules so they compile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c39172a34832db5b66ac63b01b124