### PR TITLE
Add manual guest sign-in flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Login Behavior
+
+On each launch the app shows a role selection screen. No user ID is created until you choose a role, at which point the app signs in anonymously and stores your selection.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders loading message initially', () => {
+test('shows login screen after initial load', async () => {
   render(<App />);
-  const loadingElement = screen.getByText(/loading auditsim pro/i);
-  expect(loadingElement).toBeInTheDocument();
+  const roleHeading = await screen.findByText(/select your role/i);
+  expect(roleHeading).toBeInTheDocument();
 });

--- a/src/AppPages.js
+++ b/src/AppPages.js
@@ -31,7 +31,7 @@ import RoleRoute from './routes/RoleRoute'; // CHANGED: RoleRoute imported
 
 // --- Pages ---
 const RoleSelectionPage = () => {
-    const { setRole, userProfile, currentUser, loadingAuth } = useAuth();
+    const { setRole, userProfile, currentUser, loadingAuth, signInAsGuest } = useAuth();
     const { navigate } = useRoute();
     const [isSettingRole, setIsSettingRole] = useState(false);
 
@@ -41,6 +41,9 @@ const RoleSelectionPage = () => {
 
     const handleSelectRole = async (role) => {
         setIsSettingRole(true);
+        if (!currentUser) {
+            await signInAsGuest();
+        }
         await setRole(role);
         setIsSettingRole(false);
     };
@@ -57,7 +60,7 @@ const RoleSelectionPage = () => {
                     <Button onClick={() => handleSelectRole('admin')} className="w-full py-3 text-lg" isLoading={isSettingRole} disabled={isSettingRole}><Briefcase size={20} className="inline mr-2" /> Administrator / Instructor</Button>
                     <Button onClick={() => handleSelectRole('trainee')} variant="secondary" className="w-full py-3 text-lg" isLoading={isSettingRole} disabled={isSettingRole}><User size={20} className="inline mr-2" /> Auditor Trainee</Button>
                 </div>
-                <p className="mt-6 text-sm text-gray-500">Your User ID: {currentUser?.uid || "Not Available"}</p>
+                <p className="mt-6 text-sm text-gray-500">Your User ID: {currentUser?.uid || "Not signed in"}</p>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- allow manual sign-in with `signInAsGuest`
- rely on Firebase session restore instead of automatic anonymous login
- adjust role selection page to sign in when picking a role
- expose UID only after login and show not-signed-in message
- update tests for the new login screen
- document login behavior in README

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684c47d5300c832da2ea69a957079744