### PR TITLE
Fix role setting when new anonymous user signs in

### DIFF
--- a/src/services/roleService.js
+++ b/src/services/roleService.js
@@ -2,13 +2,35 @@ import { doc, getDoc } from 'firebase/firestore';
 
 const roleCache = {};
 
+function readSession(uid) {
+  if (typeof sessionStorage === 'undefined') return null;
+  return sessionStorage.getItem(`role_${uid}`);
+}
+
+function writeSession(uid, role) {
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.setItem(`role_${uid}`, role);
+  }
+}
+
 export async function getRole(db, uid) {
   if (roleCache[uid]) return roleCache[uid];
+  const stored = readSession(uid);
+  if (stored) {
+    roleCache[uid] = stored;
+    return stored;
+  }
   const snap = await getDoc(doc(db, 'roles', uid));
   if (!snap.exists()) {
     throw new Error('Role not found');
   }
   const data = snap.data();
   roleCache[uid] = data.role;
+  writeSession(uid, data.role);
   return data.role;
+}
+
+export function cacheRole(uid, role) {
+  roleCache[uid] = role;
+  writeSession(uid, role);
 }


### PR DESCRIPTION
## Summary
- fix new profile creation in `setRole` to use user data
- simplify router with config objects and protect trainee routes
- store roles in sessionStorage
- move profile and role logic to `UserProvider`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684c521cb298832da817ec219ffd2429