### PR TITLE
Implement admin pages with Firestore logic

### DIFF
--- a/src/AppPages.js
+++ b/src/AppPages.js
@@ -1,33 +1,31 @@
 // ---------- React and Firebase Imports (Core) ----------
-import React, { useState, useEffect, createContext, useContext, useCallback, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 
 // ---------- Firebase Service Imports (from AppCore, assuming they are correctly exported there) ----------
-import {
-    doc, setDoc, getDoc, deleteDoc,
-    collection, addDoc, query, where,
-    Timestamp, onSnapshot, collectionGroup
-} from 'firebase/firestore';
-import { getFunctions, httpsCallable } from 'firebase/functions';
-import { ref as storageRef, uploadBytesResumable, getDownloadURL } from 'firebase/storage';
+// Firebase utilities are used within dedicated page components
 
 // ---------- Icon Imports (Lucide) ----------
 import {
-    PlusCircle, BookOpen, User, LogOut, Eye, Trash2, Edit3, FileText,
-    Send, Briefcase, Users, FilePlus, ListChecks, UploadCloud, Users2, Paperclip,
-    ListFilter, AlertTriangle, CheckCircle2, Loader2, FileQuestion, XCircle
+    Users, Briefcase, User, LogOut, Loader2, XCircle
 } from 'lucide-react';
 
 // ---------- Core App Logic Imports (from AppCore.js) ----------
 import {
-    Button, Input, Textarea, Select,
-    useModal, useAuth, useUser, useRoute,
+    Button,
+    useAuth, useUser, useRoute,
     ModalProvider, AuthProvider, UserProvider, RouterProvider,
-    CLASSIFICATION_OPTIONS,
-    db, storage, FirestorePaths, appId,
-    firebaseApp
+    appId
 } from './AppCore';
 
 import RoleRoute from './routes/RoleRoute';
+
+// Import dedicated page components
+import AdminDashboardPage from './pages/AdminDashboardPage';
+import AdminUserManagementPage from './pages/AdminUserManagementPage';
+import AdminCaseSubmissionsPage from './pages/AdminCaseSubmissionsPage';
+import CaseFormPage from './pages/CaseFormPage';
+import TraineeDashboardPage from './pages/TraineeDashboardPage';
+import TraineeCaseViewPage from './pages/TraineeCaseViewPage';
 
 // --- Pages ---
 const RoleSelectionPage = () => {
@@ -82,50 +80,7 @@ const UnauthorizedPage = () => (
     </div>
 );
 
-// --- Placeholder Pages for Demo Purposes ---
-// These simple components allow the application to compile even
-// when the full page implementations are not present.
-const AdminDashboardPage = () => (
-    <div className="p-4 text-center">
-        <h2 className="text-xl font-semibold mb-2">Admin Dashboard</h2>
-        <p>Welcome to the admin dashboard.</p>
-    </div>
-);
-
-const AdminUserManagementPage = () => (
-    <div className="p-4 text-center">
-        <h2 className="text-xl font-semibold mb-2">User Management</h2>
-        <p>Manage your users here.</p>
-    </div>
-);
-
-const AdminCaseSubmissionsPage = ({ params }) => (
-    <div className="p-4 text-center">
-        <h2 className="text-xl font-semibold mb-2">Case Submissions</h2>
-        {params?.caseId && <p>Viewing submissions for case {params.caseId}</p>}
-    </div>
-);
-
-const CaseFormPage = ({ params }) => (
-    <div className="p-4 text-center">
-        <h2 className="text-xl font-semibold mb-2">Case Form</h2>
-        {params?.caseId ? <p>Editing case {params.caseId}</p> : <p>Create a new case</p>}
-    </div>
-);
-
-const TraineeDashboardPage = () => (
-    <div className="p-4 text-center">
-        <h2 className="text-xl font-semibold mb-2">Trainee Dashboard</h2>
-        <p>Welcome trainee.</p>
-    </div>
-);
-
-const TraineeCaseViewPage = ({ params }) => (
-    <div className="p-4 text-center">
-        <h2 className="text-xl font-semibold mb-2">Case View</h2>
-        {params?.caseId && <p>Viewing case {params.caseId}</p>}
-    </div>
-);
+// --- Page Components imported above are used for routing ---
 
 // --- routes configuration ---
 const adminRoutes = {

--- a/src/pages/AdminCaseSubmissionsPage.jsx
+++ b/src/pages/AdminCaseSubmissionsPage.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { collectionGroup, query, where, onSnapshot } from 'firebase/firestore';
+import { db, Button, useRoute, FirestorePaths } from '../AppCore';
+
+export default function AdminCaseSubmissionsPage({ params }) {
+  const { navigate } = useRoute();
+  const caseId = params?.caseId;
+  const [submissions, setSubmissions] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const q = query(collectionGroup(db, 'caseSubmissions'), where('caseId', '==', caseId));
+    const unsub = onSnapshot(q, snap => {
+      setSubmissions(snap.docs.map(d => d.data()));
+      setLoading(false);
+    }, err => {
+      console.error('Failed to fetch submissions', err);
+      setLoading(false);
+    });
+    return unsub;
+  }, [caseId]);
+
+  if (loading) return <div>Loading submissions...</div>;
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-3">Submissions for Case {caseId}</h2>
+      {submissions.length === 0 && <p>No submissions yet.</p>}
+      <ul className="space-y-2">
+        {submissions.map((s, idx) => (
+          <li key={idx} className="border rounded p-2">
+            <div className="text-sm">User: {s.userId}</div>
+            <div className="text-sm">Submitted: {s.submittedAt?.toDate?.().toLocaleString?.() ?? ''}</div>
+          </li>
+        ))}
+      </ul>
+      <Button className="mt-4" variant="secondary" onClick={() => navigate('/admin/dashboard')}>Back</Button>
+    </div>
+  );
+}

--- a/src/pages/AdminDashboardPage.jsx
+++ b/src/pages/AdminDashboardPage.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { collection, onSnapshot, query } from 'firebase/firestore';
+import { Eye, Edit3, PlusCircle } from 'lucide-react';
+import { db, FirestorePaths, Button, useRoute } from '../AppCore';
+
+export default function AdminDashboardPage() {
+  const { navigate } = useRoute();
+  const [cases, setCases] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const q = query(collection(db, FirestorePaths.CASES_COLLECTION()));
+    const unsub = onSnapshot(q, snap => {
+      setCases(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+      setLoading(false);
+    }, err => {
+      console.error('Failed to fetch cases', err);
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  if (loading) {
+    return <div>Loading cases...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button onClick={() => navigate('/admin/create-case')}> <PlusCircle className="inline mr-1" size={16}/> New Case</Button>
+      </div>
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead>
+          <tr>
+            <th className="px-2 py-1 text-left text-sm font-semibold">Case Name</th>
+            <th className="px-2 py-1" colSpan="2">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {cases.map(c => (
+            <tr key={c.id}>
+              <td className="px-2 py-1">{c.caseName}</td>
+              <td className="px-2 py-1 text-right space-x-2">
+                <Button onClick={() => navigate(`/admin/edit-case/${c.id}`)} variant="secondary"><Edit3 size={16} className="inline mr-1"/>Edit</Button>
+                <Button onClick={() => navigate(`/admin/case-submissions/${c.id}`)} variant="secondary"><Eye size={16} className="inline mr-1"/>Submissions</Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/AdminUserManagementPage.jsx
+++ b/src/pages/AdminUserManagementPage.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { db, FirestorePaths } from '../AppCore';
+
+export default function AdminUserManagementPage() {
+  const [userIds, setUserIds] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const snap = await getDocs(collection(db, FirestorePaths.USERS_COLLECTION()));
+        setUserIds(snap.docs.map(d => d.id));
+      } catch (err) {
+        console.error('Failed to list users', err);
+      }
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return <div>Loading users...</div>;
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-2">User IDs</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        {userIds.map(id => <li key={id}>{id}</li>)}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/CaseFormPage.jsx
+++ b/src/pages/CaseFormPage.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc, setDoc, serverTimestamp, collection } from 'firebase/firestore';
+import { useAuth, db, FirestorePaths, Input, Textarea, Button, useRoute } from '../AppCore';
+
+export default function CaseFormPage({ params }) {
+  const caseId = params?.caseId;
+  const { currentUser } = useAuth();
+  const { navigate } = useRoute();
+  const [form, setForm] = useState({ caseName: '', visibleToUserIds: '' });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!caseId) { setLoading(false); return; }
+    async function load() {
+      try {
+        const snap = await getDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)));
+        if (snap.exists()) {
+          const d = snap.data();
+          setForm({ caseName: d.caseName || '', visibleToUserIds: (d.visibleToUserIds || []).join(',') });
+        }
+      } catch (err) {
+        console.error('Failed to load case', err);
+      }
+      setLoading(false);
+    }
+    load();
+  }, [caseId]);
+
+  const handleChange = e => {
+    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const data = {
+      caseName: form.caseName,
+      disbursements: [],
+      invoiceMappings: [],
+      visibleToUserIds: form.visibleToUserIds.split(',').map(s => s.trim()).filter(Boolean),
+      updatedAt: serverTimestamp(),
+      _deleted: false,
+    };
+    try {
+      if (caseId) {
+        const snap = await getDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)));
+        if (snap.exists()) {
+          const existing = snap.data();
+          await setDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)), { ...existing, ...data }, { merge: true });
+        }
+      } else {
+        const newDocRef = doc(collection(db, FirestorePaths.CASES_COLLECTION()));
+        await setDoc(newDocRef, { ...data, createdBy: currentUser.uid, createdAt: serverTimestamp() });
+      }
+      navigate('/admin/dashboard');
+    } catch (err) {
+      console.error('Failed to save case', err);
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-xl">
+      <div>
+        <label className="block text-sm font-medium mb-1">Case Name</label>
+        <Input name="caseName" value={form.caseName} onChange={handleChange} required />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Visible To User IDs (comma separated)</label>
+        <Textarea name="visibleToUserIds" value={form.visibleToUserIds} onChange={handleChange} rows={3} />
+      </div>
+      <Button type="submit">{caseId ? 'Update Case' : 'Create Case'}</Button>
+    </form>
+  );
+}

--- a/src/pages/TraineeCaseViewPage.jsx
+++ b/src/pages/TraineeCaseViewPage.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { db, FirestorePaths, Button, useRoute } from '../AppCore';
+
+export default function TraineeCaseViewPage({ params }) {
+  const caseId = params?.caseId;
+  const { navigate } = useRoute();
+  const [caseData, setCaseData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const snap = await getDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)));
+        if (snap.exists()) setCaseData(snap.data());
+      } catch (err) {
+        console.error('Failed to load case', err);
+      }
+      setLoading(false);
+    }
+    load();
+  }, [caseId]);
+
+  if (loading) return <div>Loading...</div>;
+  if (!caseData) return <div>Case not found.</div>;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">{caseData.caseName}</h2>
+      <Button variant="secondary" onClick={() => navigate('/trainee/dashboard')}>Back</Button>
+    </div>
+  );
+}

--- a/src/pages/TraineeDashboardPage.jsx
+++ b/src/pages/TraineeDashboardPage.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { firebaseApp, Button, useRoute } from '../AppCore';
+
+export default function TraineeDashboardPage() {
+  const { navigate } = useRoute();
+  const [cases, setCases] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fn = httpsCallable(getFunctions(firebaseApp), 'getMyVisibleCases');
+    fn().then(res => {
+      setCases(res.data.cases || []);
+      setLoading(false);
+    }).catch(err => {
+      console.error('Failed to load cases', err);
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) return <div>Loading cases...</div>;
+
+  return (
+    <div className="space-y-4">
+      {cases.length === 0 && <p>No available cases.</p>}
+      <ul className="space-y-2">
+        {cases.map(c => (
+          <li key={c.id} className="border rounded p-2 flex justify-between">
+            <span>{c.caseName}</span>
+            <Button variant="secondary" onClick={() => navigate(`/trainee/case/${c.id}`)}>Open</Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create new page components for admin and trainee flows
- implement case creation/editing, listing, and submissions views
- show user IDs in admin user management
- call Cloud Function in trainee dashboard
- wire up routing in `AppPages`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c5a1c0908832d9bf1ad9b8f80fa11