### PR TITLE
Enhance admin and trainee pages

### DIFF
--- a/src/pages/AdminCaseSubmissionsPage.jsx
+++ b/src/pages/AdminCaseSubmissionsPage.jsx
@@ -1,40 +1,106 @@
 import React, { useEffect, useState } from 'react';
-import { collectionGroup, query, where, onSnapshot } from 'firebase/firestore';
-import { db, Button, useRoute, FirestorePaths } from '../AppCore';
+import { doc, getDoc, collection, getDocs } from 'firebase/firestore';
+import { db, FirestorePaths, Button, useRoute, useModal } from '../AppCore';
 
 export default function AdminCaseSubmissionsPage({ params }) {
+  const { caseId } = params;
   const { navigate } = useRoute();
-  const caseId = params?.caseId;
+  const { showModal } = useModal();
   const [submissions, setSubmissions] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loadingSubmissions, setLoadingSubmissions] = useState(true);
+  const [caseName, setCaseName] = useState('');
 
   useEffect(() => {
-    const q = query(collectionGroup(db, 'caseSubmissions'), where('caseId', '==', caseId));
-    const unsub = onSnapshot(q, snap => {
-      setSubmissions(snap.docs.map(d => d.data()));
-      setLoading(false);
-    }, err => {
-      console.error('Failed to fetch submissions', err);
-      setLoading(false);
-    });
-    return unsub;
-  }, [caseId]);
+    if (!caseId) {
+      navigate('/admin');
+      return;
+    }
+    setLoadingSubmissions(true);
 
-  if (loading) return <div>Loading submissions...</div>;
+    const caseRef = doc(db, FirestorePaths.CASE_DOCUMENT(caseId));
+    getDoc(caseRef).then(docSnap => {
+      if (docSnap.exists()) {
+        setCaseName(docSnap.data().caseName);
+      }
+    });
+
+    const usersCollectionRef = collection(db, FirestorePaths.USERS_COLLECTION());
+    getDocs(usersCollectionRef)
+      .then(async (userDocsSnapshot) => {
+        const allSubmissions = [];
+        for (const userDoc of userDocsSnapshot.docs) {
+          const userId = userDoc.id;
+          const submissionRef = doc(db, FirestorePaths.USER_CASE_SUBMISSION(userId, caseId));
+          const submissionSnap = await getDoc(submissionRef);
+          if (submissionSnap.exists()) {
+            allSubmissions.push({ id: submissionSnap.id, userId, ...submissionSnap.data() });
+          }
+        }
+        setSubmissions(allSubmissions);
+        setLoadingSubmissions(false);
+      })
+      .catch((error) => {
+        console.error('Error fetching submissions:', error);
+        showModal('Error fetching submissions: ' + error.message, 'Error');
+        setLoadingSubmissions(false);
+      });
+  }, [caseId, navigate, showModal]);
+
+  if (loadingSubmissions) return <div className="p-4 text-center">Loading submissions...</div>;
 
   return (
-    <div>
-      <h2 className="text-lg font-semibold mb-3">Submissions for Case {caseId}</h2>
-      {submissions.length === 0 && <p>No submissions yet.</p>}
-      <ul className="space-y-2">
-        {submissions.map((s, idx) => (
-          <li key={idx} className="border rounded p-2">
-            <div className="text-sm">User: {s.userId}</div>
-            <div className="text-sm">Submitted: {s.submittedAt?.toDate?.().toLocaleString?.() ?? ''}</div>
-          </li>
-        ))}
-      </ul>
-      <Button className="mt-4" variant="secondary" onClick={() => navigate('/admin/dashboard')}>Back</Button>
+    <div className="p-6 bg-gray-50 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-800">Submissions for:</h1>
+            <h2 className="text-xl text-blue-600">{caseName || caseId}</h2>
+          </div>
+          <Button onClick={() => navigate('/admin')} variant="secondary">
+            &larr; Back to Dashboard
+          </Button>
+        </div>
+        {submissions.length === 0 ? (
+          <div className="text-center py-10 bg-white rounded-lg shadow">
+            <p className="text-gray-600 text-xl">No submissions found for this case.</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {submissions.map((submission) => (
+              <div key={submission.userId} className="bg-white p-6 rounded-lg shadow-md">
+                <h3 className="text-lg font-semibold text-gray-700">
+                  User ID: <span className="font-normal text-sm break-all">{submission.userId}</span>
+                </h3>
+                <p className="text-sm text-gray-500">Submitted At: {submission.submittedAt?.toDate ? submission.submittedAt.toDate().toLocaleString() : 'N/A'}</p>
+                <div className="mt-3">
+                  <p className="text-sm font-medium text-gray-600">Selected Payment IDs:</p>
+                  {submission.selectedPaymentIds && submission.selectedPaymentIds.length > 0 ? (
+                    <ul className="list-disc list-inside pl-4 text-sm text-gray-500">
+                      {submission.selectedPaymentIds.map((pid) => (
+                        <li key={pid}>{pid}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-gray-500">None</p>
+                  )}
+                </div>
+                <div className="mt-2">
+                  <p className="text-sm font-medium text-gray-600">Retrieved Documents (Filenames):</p>
+                  {submission.retrievedDocuments && submission.retrievedDocuments.length > 0 ? (
+                    <ul className="list-disc list-inside pl-4 text-sm text-gray-500">
+                      {submission.retrievedDocuments.map((doc) => (
+                        <li key={doc.fileName}>{doc.fileName}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-gray-500">None</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/AdminDashboardPage.jsx
+++ b/src/pages/AdminDashboardPage.jsx
@@ -1,53 +1,110 @@
 import React, { useEffect, useState } from 'react';
-import { collection, onSnapshot, query } from 'firebase/firestore';
-import { Eye, Edit3, PlusCircle } from 'lucide-react';
-import { db, FirestorePaths, Button, useRoute } from '../AppCore';
+import { collection, onSnapshot, query, doc, setDoc, Timestamp } from 'firebase/firestore';
+import { FilePlus, Users2, Edit3, ListFilter, Trash2 } from 'lucide-react';
+import { db, FirestorePaths, Button, useRoute, useModal } from '../AppCore';
 
 export default function AdminDashboardPage() {
   const { navigate } = useRoute();
+  const { showModal } = useModal();
   const [cases, setCases] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loadingCases, setLoadingCases] = useState(true);
 
   useEffect(() => {
-    const q = query(collection(db, FirestorePaths.CASES_COLLECTION()));
-    const unsub = onSnapshot(q, snap => {
-      setCases(snap.docs.map(d => ({ id: d.id, ...d.data() })));
-      setLoading(false);
-    }, err => {
-      console.error('Failed to fetch cases', err);
-      setLoading(false);
+    const casesCollectionRef = collection(db, FirestorePaths.CASES_COLLECTION());
+    const q = query(casesCollectionRef);
+    const unsubscribe = onSnapshot(q, (querySnapshot) => {
+      const casesData = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+      setCases(casesData);
+      setLoadingCases(false);
+    }, (error) => {
+      console.error('Error fetching cases: ', error);
+      showModal('Error fetching cases: ' + error.message, 'Error');
+      setLoadingCases(false);
     });
-    return unsub;
-  }, []);
+    return () => unsubscribe();
+  }, [showModal]);
 
-  if (loading) {
-    return <div>Loading cases...</div>;
-  }
+  const deleteCase = async (caseId) => {
+    showModal(
+      <> 
+        <p className="text-gray-700">Are you sure you want to delete this case? This action marks it as deleted but does not permanently remove data immediately.</p>
+      </>,
+      'Confirm Deletion',
+      (hideModal) => (
+        <>
+          <Button onClick={hideModal} variant="secondary">Cancel</Button>
+          <Button
+            onClick={async () => {
+              hideModal();
+              try {
+                await setDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)), { _deleted: true, updatedAt: Timestamp.now() }, { merge: true });
+                showModal('Case marked for deletion.', 'Success');
+              } catch (error) {
+                console.error('Error deleting case:', error);
+                showModal('Error deleting case: ' + error.message, 'Error');
+              }
+            }}
+            variant="danger"
+            className="ml-2"
+          >
+            Confirm Delete
+          </Button>
+        </>
+      )
+    );
+  };
+
+  if (loadingCases) return <div className="p-4 text-center">Loading cases...</div>;
 
   return (
-    <div className="space-y-4">
-      <div className="flex justify-end">
-        <Button onClick={() => navigate('/admin/create-case')}> <PlusCircle className="inline mr-1" size={16}/> New Case</Button>
+    <div className="p-6 bg-gray-50 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-800">Admin Dashboard</h1>
+          <div className="space-x-2">
+            <Button onClick={() => navigate('/admin/user-management')}>
+              <Users2 size={20} className="inline mr-2" /> User Management
+            </Button>
+            <Button onClick={() => navigate('/admin/create-case')}>
+              <FilePlus size={20} className="inline mr-2" /> Create New Case
+            </Button>
+          </div>
+        </div>
+        {cases.filter(c => !c._deleted).length === 0 ? (
+          <div className="text-center py-10 bg-white rounded-lg shadow">
+            <ListFilter size={48} className="mx-auto text-gray-400 mb-4" />
+            <p className="text-gray-600 text-xl">No active cases found.</p>
+            <p className="text-gray-500 mt-2">Get started by creating a new audit case.</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {cases.filter(c => !c._deleted).map(caseData => (
+              <div key={caseData.id} className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow">
+                <div className="flex justify-between items-start">
+                  <div>
+                    <h2 className="text-xl font-semibold text-blue-700">{caseData.caseName}</h2>
+                    <p className="text-sm text-gray-500">ID: {caseData.id}</p>
+                    <p className="text-sm text-gray-500">Disbursements: {caseData.disbursements?.length || 0}</p>
+                    <p className="text-sm text-gray-500">Mappings: {caseData.invoiceMappings?.length || 0}</p>
+                    <p className="text-sm text-gray-500">Visible to: {caseData.visibleToUserIds && caseData.visibleToUserIds.length > 0 ? `${caseData.visibleToUserIds.length} user(s)` : 'All Users'}</p>
+                  </div>
+                  <div className="flex flex-col space-y-2 items-end">
+                    <Button onClick={() => navigate(`/admin/case-submissions/${caseData.id}`)} variant="secondary" className="px-3 py-1 text-sm w-full">
+                      <ListFilter size={16} className="inline mr-1" /> View Submissions
+                    </Button>
+                    <Button onClick={() => navigate(`/admin/edit-case/${caseData.id}`)} variant="secondary" className="px-3 py-1 text-sm w-full">
+                      <Edit3 size={16} className="inline mr-1" /> Edit Case
+                    </Button>
+                    <Button onClick={() => deleteCase(caseData.id)} variant="danger" className="px-3 py-1 text-sm w-full">
+                      <Trash2 size={16} className="inline mr-1" /> Delete Case
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead>
-          <tr>
-            <th className="px-2 py-1 text-left text-sm font-semibold">Case Name</th>
-            <th className="px-2 py-1" colSpan="2">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-200">
-          {cases.map(c => (
-            <tr key={c.id}>
-              <td className="px-2 py-1">{c.caseName}</td>
-              <td className="px-2 py-1 text-right space-x-2">
-                <Button onClick={() => navigate(`/admin/edit-case/${c.id}`)} variant="secondary"><Edit3 size={16} className="inline mr-1"/>Edit</Button>
-                <Button onClick={() => navigate(`/admin/case-submissions/${c.id}`)} variant="secondary"><Eye size={16} className="inline mr-1"/>Submissions</Button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
     </div>
   );
 }

--- a/src/pages/AdminUserManagementPage.jsx
+++ b/src/pages/AdminUserManagementPage.jsx
@@ -1,34 +1,85 @@
 import React, { useEffect, useState } from 'react';
-import { collection, getDocs } from 'firebase/firestore';
-import { db, FirestorePaths } from '../AppCore';
+import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
+import { db, FirestorePaths, Button, useRoute, useModal } from '../AppCore';
 
 export default function AdminUserManagementPage() {
-  const [userIds, setUserIds] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [users, setUsers] = useState([]);
+  const [loadingUsers, setLoadingUsers] = useState(true);
+  const { navigate } = useRoute();
+  const { showModal } = useModal();
 
   useEffect(() => {
-    async function load() {
-      try {
-        const snap = await getDocs(collection(db, FirestorePaths.USERS_COLLECTION()));
-        setUserIds(snap.docs.map(d => d.id));
-      } catch (err) {
-        console.error('Failed to list users', err);
-      }
-      setLoading(false);
-    }
-    load();
-  }, []);
+    setLoadingUsers(true);
+    const usersCollectionRef = collection(db, FirestorePaths.USERS_COLLECTION());
+    getDocs(usersCollectionRef)
+      .then(async (userDocsSnapshot) => {
+        const usersData = [];
+        for (const userDoc of userDocsSnapshot.docs) {
+          const userId = userDoc.id;
+          const profileRef = doc(db, FirestorePaths.USER_PROFILE(userId));
+          const profileSnap = await getDoc(profileRef);
+          if (profileSnap.exists()) {
+            usersData.push({ id: userId, ...profileSnap.data() });
+          } else {
+            usersData.push({ id: userId, role: 'N/A (No profile data)' });
+          }
+        }
+        setUsers(usersData);
+        setLoadingUsers(false);
+      })
+      .catch((error) => {
+        console.error('Error fetching users:', error);
+        showModal('Error fetching users: ' + error.message, 'Error');
+        setLoadingUsers(false);
+      });
+  }, [showModal]);
 
-  if (loading) {
-    return <div>Loading users...</div>;
-  }
+  if (loadingUsers) return <div className="p-4 text-center">Loading users...</div>;
 
   return (
-    <div>
-      <h2 className="text-lg font-semibold mb-2">User IDs</h2>
-      <ul className="list-disc pl-5 space-y-1">
-        {userIds.map(id => <li key={id}>{id}</li>)}
-      </ul>
+    <div className="p-6 bg-gray-50 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-800">User Management</h1>
+          <Button onClick={() => navigate('/admin')} variant="secondary">
+            &larr; Back to Dashboard
+          </Button>
+        </div>
+        {users.length === 0 ? (
+          <div className="text-center py-10 bg-white rounded-lg shadow">
+            <p className="text-gray-600 text-xl">No users found.</p>
+          </div>
+        ) : (
+          <div className="bg-white shadow-md rounded-lg overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    User ID
+                  </th>
+                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Role
+                  </th>
+                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Profile Created At
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {users.map((user) => (
+                  <tr key={user.id}>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 break-all">{user.id}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 capitalize">{user.role}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {user.createdAt?.toDate ? user.createdAt.toDate().toLocaleString() : 'N/A'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/CaseFormPage.jsx
+++ b/src/pages/CaseFormPage.jsx
@@ -1,75 +1,449 @@
 import React, { useEffect, useState } from 'react';
-import { doc, getDoc, setDoc, serverTimestamp, collection } from 'firebase/firestore';
-import { useAuth, db, FirestorePaths, Input, Textarea, Button, useRoute } from '../AppCore';
+import { doc, getDoc, setDoc, collection, addDoc, Timestamp } from 'firebase/firestore';
+import { storage } from '../AppCore';
+import { ref as storageRef, uploadBytesResumable, getDownloadURL } from 'firebase/storage';
+import { useAuth, db, FirestorePaths, Input, Textarea, Button, useRoute, useModal } from '../AppCore';
+import { PlusCircle, Trash2, Paperclip, CheckCircle2, AlertTriangle, UploadCloud } from 'lucide-react';
 
 export default function CaseFormPage({ params }) {
-  const caseId = params?.caseId;
-  const { currentUser } = useAuth();
+  const { caseId: editingCaseId } = params || {};
+  const isEditing = !!editingCaseId;
   const { navigate } = useRoute();
-  const [form, setForm] = useState({ caseName: '', visibleToUserIds: '' });
-  const [loading, setLoading] = useState(true);
+  const { userId } = useAuth();
+  const { showModal } = useModal();
+
+  const initialDisbursement = () => ({ _tempId: crypto.randomUUID(), paymentId: '', payee: '', amount: '', paymentDate: '' });
+  const initialMapping = () => ({ _tempId: crypto.randomUUID(), paymentId: '', fileName: '', storagePath: '', clientSideFile: null, uploadProgress: undefined, uploadError: null, downloadURL: '' });
+
+  const [caseName, setCaseName] = useState('');
+  const [visibleToUserIdsStr, setVisibleToUserIdsStr] = useState('');
+  const [disbursements, setDisbursements] = useState([initialDisbursement()]);
+  const [invoiceMappings, setInvoiceMappings] = useState([initialMapping()]);
+  const [loading, setLoading] = useState(false);
+  const [originalCaseData, setOriginalCaseData] = useState(null);
+  const disbursementCsvInputRef = React.useRef(null);
 
   useEffect(() => {
-    if (!caseId) { setLoading(false); return; }
-    async function load() {
-      try {
-        const snap = await getDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)));
-        if (snap.exists()) {
-          const d = snap.data();
-          setForm({ caseName: d.caseName || '', visibleToUserIds: (d.visibleToUserIds || []).join(',') });
-        }
-      } catch (err) {
-        console.error('Failed to load case', err);
+    if (isEditing && editingCaseId) {
+      setLoading(true);
+      const caseRef = doc(db, FirestorePaths.CASE_DOCUMENT(editingCaseId));
+      getDoc(caseRef)
+        .then((docSnap) => {
+          if (docSnap.exists()) {
+            const data = docSnap.data();
+            setOriginalCaseData(data);
+            setCaseName(data.caseName || '');
+            setVisibleToUserIdsStr((data.visibleToUserIds || []).join(', '));
+            setDisbursements(data.disbursements?.map((d) => ({ ...d, _tempId: d._tempId || crypto.randomUUID() })) || [initialDisbursement()]);
+            setInvoiceMappings(
+              data.invoiceMappings?.map((m) => ({ ...m, _tempId: m._tempId || crypto.randomUUID(), clientSideFile: null, uploadProgress: m.storagePath ? 100 : undefined, uploadError: null })) || [initialMapping()]
+            );
+          } else {
+            showModal('Case not found.', 'Error');
+            navigate('/admin');
+          }
+          setLoading(false);
+        })
+        .catch((error) => {
+          console.error('Error fetching case for editing:', error);
+          showModal('Error fetching case: ' + error.message, 'Error');
+          setLoading(false);
+          navigate('/admin');
+        });
+    } else {
+      setCaseName('');
+      setVisibleToUserIdsStr('');
+      setDisbursements([initialDisbursement()]);
+      setInvoiceMappings([initialMapping()]);
+      setOriginalCaseData(null);
+    }
+  }, [isEditing, editingCaseId, navigate, showModal]);
+
+  const handleDisbursementChange = (index, updatedItem) => {
+    const newDisbursements = [...disbursements];
+    newDisbursements[index] = updatedItem;
+    setDisbursements(newDisbursements);
+  };
+  const addDisbursement = () => setDisbursements([...disbursements, initialDisbursement()]);
+  const removeDisbursement = (index) => setDisbursements(disbursements.filter((_, i) => i !== index));
+
+  const handleMappingChange = (index, updatedItem) => {
+    const newMappings = [...invoiceMappings];
+    newMappings[index] = updatedItem;
+    setInvoiceMappings(newMappings);
+  };
+
+  const handleMappingFileSelect = (index, file) => {
+    setInvoiceMappings((prevMappings) =>
+      prevMappings.map((m, i) =>
+        i === index ? { ...m, clientSideFile: file, fileName: file.name, storagePath: '', uploadProgress: 0, uploadError: null, downloadURL: '' } : m
+      )
+    );
+    console.log(`File selected: ${file.name}. It will be uploaded on save.`);
+  };
+
+  const addMapping = () => {
+    setInvoiceMappings([...invoiceMappings, initialMapping()]);
+  };
+  const removeMapping = (index) => setInvoiceMappings(invoiceMappings.filter((_, i) => i !== index));
+
+  const availablePaymentIdsForMapping = disbursements.map((d) => d.paymentId).filter((id) => id);
+
+  const handleCsvImport = (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = e.target.result;
+      if (!text || text.trim() === '') {
+        showModal('CSV file is empty or contains no processable content.', 'CSV Import Error');
+        return;
       }
+      try {
+        const lines = text.split(/\r\n|\n/);
+        if (lines.length <= 1 && !(lines.length === 1 && lines[0].trim() !== '')) {
+          showModal('CSV file is empty or contains only a header row.', 'CSV Import Error');
+          if (disbursementCsvInputRef.current) disbursementCsvInputRef.current.value = '';
+          return;
+        }
+        const importedDisbursements = lines
+          .slice(1)
+          .map((line) => {
+            const parts = line.split(',');
+            if (parts.length >= 4) {
+              const [paymentId, payee, amount, paymentDate] = parts;
+              if (paymentId && payee && amount && paymentDate) {
+                return {
+                  _tempId: crypto.randomUUID(),
+                  paymentId: paymentId.trim(),
+                  payee: payee.trim(),
+                  amount: amount.trim(),
+                  paymentDate: paymentDate.trim(),
+                };
+              }
+            }
+            return null;
+          })
+          .filter((d) => d !== null);
+
+        if (importedDisbursements.length > 0) {
+          setDisbursements(importedDisbursements);
+          showModal(`${importedDisbursements.length} disbursements imported successfully. Please review. Existing manual entries were replaced.`, 'CSV Import');
+        } else {
+          showModal('No valid disbursements found in CSV or CSV format is incorrect. Expected columns: PaymentID,Payee,Amount,PaymentDate', 'CSV Import Error');
+        }
+      } catch (error) {
+        console.error('Error parsing CSV:', error);
+        showModal('Error parsing CSV file: ' + error.message, 'CSV Import Error');
+      }
+      if (disbursementCsvInputRef.current) {
+        disbursementCsvInputRef.current.value = '';
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const uploadFileAndGetMetadata = async (mappingItem, caseIdForUpload) => {
+    if (!mappingItem.clientSideFile) {
+      const { clientSideFile, uploadProgress, uploadError, _tempId, ...restOfMapping } = mappingItem;
+      return restOfMapping.fileName ? restOfMapping : null;
+    }
+
+    const file = mappingItem.clientSideFile;
+    if (!caseIdForUpload) {
+      const errorMsg = 'Cannot upload file: Case ID is not yet finalized for new case.';
+      console.error(errorMsg, mappingItem);
+      setInvoiceMappings((prev) => prev.map((m) => (m._tempId === mappingItem._tempId ? { ...m, uploadError: errorMsg, uploadProgress: undefined } : m)));
+      throw new Error(errorMsg);
+    }
+    const finalStoragePath = `case_documents/${caseIdForUpload}/${file.name}`;
+
+    setInvoiceMappings((prev) => prev.map((m) => (m._tempId === mappingItem._tempId ? { ...m, storagePath: finalStoragePath, uploadProgress: 0, uploadError: null } : m)));
+
+    const fileRef = storageRef(storage, finalStoragePath);
+    const uploadTask = uploadBytesResumable(fileRef, file);
+
+    return new Promise((resolve) => {
+      uploadTask.on(
+        'state_changed',
+        (snapshot) => {
+          const progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+          setInvoiceMappings((prev) => prev.map((m) => (m._tempId === mappingItem._tempId ? { ...m, uploadProgress: progress } : m)));
+        },
+        (error) => {
+          console.error(`Upload failed for ${file.name}:`, error);
+          setInvoiceMappings((prev) => prev.map((m) => (m._tempId === mappingItem._tempId ? { ...m, uploadError: error.message, uploadProgress: undefined } : m)));
+          resolve({ ...mappingItem, uploadError: error.message, storagePath: finalStoragePath });
+        },
+        async () => {
+          try {
+            const downloadURL = await getDownloadURL(uploadTask.snapshot.ref);
+            console.log(`Upload successful for ${file.name}, URL: ${downloadURL}`);
+            resolve({ paymentId: mappingItem.paymentId, fileName: file.name, storagePath: finalStoragePath, downloadURL });
+          } catch (error) {
+            console.error(`Failed to get download URL for ${file.name}:`, error);
+            resolve({
+              ...mappingItem,
+              paymentId: mappingItem.paymentId,
+              fileName: file.name,
+              uploadError: 'Upload Succeeded, but failed to get download URL.',
+              storagePath: finalStoragePath,
+              downloadURL: '',
+            });
+          }
+        }
+      );
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!userId) {
+      showModal('You must be logged in to create/edit a case.', 'Authentication Error');
+      return;
+    }
+
+    if (!caseName.trim()) {
+      showModal('Case name is required.', 'Validation Error');
+      return;
+    }
+    if (disbursements.some((d) => !d.paymentId || !d.payee || !d.amount || !d.paymentDate)) {
+      showModal('All disbursement fields (Payment ID, Payee, Amount, Payment Date) are required.', 'Validation Error');
+      return;
+    }
+    const currentDisbursementIds = new Set(disbursements.map((d) => d.paymentId).filter(Boolean));
+    if (currentDisbursementIds.size !== disbursements.filter((d) => d.paymentId).length) {
+      showModal('Disbursement Payment IDs must be unique within this case.', 'Validation Error');
+      return;
+    }
+
+    const activeMappings = invoiceMappings.filter((m) => m.paymentId || m.clientSideFile || m.fileName);
+    if (activeMappings.some((m) => !m.paymentId || (!m.fileName && !m.clientSideFile))) {
+      showModal('Each active invoice mapping must have both a Payment ID selected and a PDF file associated.', 'Validation Error');
+      return;
+    }
+    if (activeMappings.some((m) => m.paymentId && !currentDisbursementIds.has(m.paymentId))) {
+      showModal('One or more invoice mappings reference a Payment ID that no longer exists in the disbursements list. Please correct the mappings or remove them.', 'Invalid Payment ID in Mapping');
+      return;
+    }
+
+    setLoading(true);
+    const visibleToUserIdsArray = visibleToUserIdsStr.split(',').map((id) => id.trim()).filter((id) => id);
+    let currentCaseId = editingCaseId;
+    let isNewCaseCreation = !isEditing;
+
+    try {
+      if (isNewCaseCreation) {
+        const tempCaseData = {
+          caseName,
+          disbursements: disbursements.map(({ _tempId, ...rest }) => rest),
+          invoiceMappings: [],
+          visibleToUserIds: visibleToUserIdsArray,
+          createdBy: userId,
+          createdAt: Timestamp.now(),
+          updatedAt: Timestamp.now(),
+        };
+        const casesCollectionRef = collection(db, FirestorePaths.CASES_COLLECTION());
+        const newCaseRef = await addDoc(casesCollectionRef, tempCaseData);
+        currentCaseId = newCaseRef.id;
+        showModal(`Case structure created (ID: ${currentCaseId}). Uploading files... This may take a moment. Please do not navigate away.`, 'Processing', null);
+      } else if (editingCaseId) {
+        currentCaseId = editingCaseId;
+        showModal(`Updating case (ID: ${currentCaseId}). Uploading any new/changed files... Please do not navigate away.`, 'Processing', null);
+      }
+
+      if (!currentCaseId) throw new Error('Case ID is missing. Cannot proceed with file uploads.');
+
+      const uploadResults = await Promise.all(
+        invoiceMappings
+          .filter((m) => m.paymentId && (m.clientSideFile || m.fileName))
+          .map((mapping) => uploadFileAndGetMetadata(mapping, currentCaseId))
+      );
+
+      const failedUploads = uploadResults.filter((result) => result && result.uploadError);
+      if (failedUploads.length > 0) {
+        const errorMessages = failedUploads.map((f) => `- ${f.fileName || 'A file'} for Payment ID ${f.paymentId}: ${f.uploadError}`).join('\n');
+        showModal(`Some file uploads failed:\n${errorMessages}\n\nPlease correct the issues by re-selecting files or removing problematic mappings, then try saving again. Case data has not been fully saved.`, 'Upload Errors');
+        setLoading(false);
+        return;
+      }
+
+      const finalInvoiceMappings = uploadResults.filter((r) => r && !r.uploadError).map(({ clientSideFile, uploadProgress, _tempId, ...rest }) => rest);
+
+      const caseDataPayload = {
+        caseName,
+        disbursements: disbursements.map(({ _tempId, ...rest }) => rest),
+        invoiceMappings: finalInvoiceMappings,
+        visibleToUserIds: visibleToUserIdsArray,
+        updatedAt: Timestamp.now(),
+        createdBy: isNewCaseCreation || !originalCaseData?.createdBy ? userId : originalCaseData.createdBy,
+        createdAt: isNewCaseCreation || !originalCaseData?.createdAt ? Timestamp.now() : originalCaseData.createdAt,
+      };
+
+      const caseRef = doc(db, FirestorePaths.CASE_DOCUMENT(currentCaseId));
+      await setDoc(caseRef, caseDataPayload, { merge: true });
+
+      showModal(`Case ${isNewCaseCreation ? 'created' : 'updated'} successfully!`, 'Success');
+      navigate('/admin');
+    } catch (error) {
+      console.error('Error saving case:', error);
+      let detailedErrorMsg = 'Error saving case: ' + error.message;
+      if (error.cause) detailedErrorMsg += `\nCause: ${error.cause.message || error.cause}`;
+      showModal(detailedErrorMsg, 'Error');
+    } finally {
       setLoading(false);
     }
-    load();
-  }, [caseId]);
-
-  const handleChange = e => {
-    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
-  const handleSubmit = async e => {
-    e.preventDefault();
-    const data = {
-      caseName: form.caseName,
-      disbursements: [],
-      invoiceMappings: [],
-      visibleToUserIds: form.visibleToUserIds.split(',').map(s => s.trim()).filter(Boolean),
-      updatedAt: serverTimestamp(),
-      _deleted: false,
-    };
-    try {
-      if (caseId) {
-        const snap = await getDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)));
-        if (snap.exists()) {
-          const existing = snap.data();
-          await setDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)), { ...existing, ...data }, { merge: true });
-        }
-      } else {
-        const newDocRef = doc(collection(db, FirestorePaths.CASES_COLLECTION()));
-        await setDoc(newDocRef, { ...data, createdBy: currentUser.uid, createdAt: serverTimestamp() });
-      }
-      navigate('/admin/dashboard');
-    } catch (err) {
-      console.error('Failed to save case', err);
+  if (loading && isEditing) return <div className="p-4 text-center">Loading case details...</div>;
+
+  const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+
+  return (
+    <div className="p-6 bg-gray-50 min-h-screen">
+      <div className="max-w-3xl mx-auto bg-white p-8 rounded-lg shadow-xl">
+        <h1 className="text-3xl font-bold text-gray-800 mb-8">{isEditing ? 'Edit Audit Case' : 'Create New Audit Case'}</h1>
+        <form onSubmit={handleSubmit} className="space-y-8">
+          <div>
+            <label htmlFor="caseName" className="block text-sm font-medium text-gray-700 mb-1">
+              Case Name
+            </label>
+            <Input id="caseName" value={caseName} onChange={(e) => setCaseName(e.target.value)} placeholder="e.g., Q1 Unrecorded Liabilities Review" required />
+          </div>
+          <div>
+            <label htmlFor="visibleToUserIds" className="block text-sm font-medium text-gray-700 mb-1">
+              Visible to User IDs (Optional)
+            </label>
+            <Textarea id="visibleToUserIds" value={visibleToUserIdsStr} onChange={(e) => setVisibleToUserIdsStr(e.target.value)} placeholder="Enter comma-separated User IDs. Leave blank for all users." />
+            <p className="text-xs text-gray-500 mt-1">If blank, the case will be visible to all trainees.</p>
+          </div>
+
+          <section>
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-semibold text-gray-700">Disbursements</h2>
+              <div>
+                <label htmlFor="csvImportDisbursements" className="bg-green-500 hover:bg-green-600 text-white px-3 py-2 rounded-md text-sm font-semibold cursor-pointer inline-flex items-center">
+                  <UploadCloud size={16} className="inline mr-2" /> Import CSV
+                </label>
+                <Input id="csvImportDisbursements" type="file" accept=".csv" onChange={handleCsvImport} className="hidden" ref={disbursementCsvInputRef} />
+              </div>
+            </div>
+            <p className="text-xs text-gray-500 mb-2">CSV format: PaymentID,Payee,Amount,PaymentDate (with header row). Dates should be YYYY-MM-DD.</p>
+            <div className="space-y-4">
+              {disbursements.map((item, index) => (
+                <DisbursementItem key={item._tempId} item={item} index={index} onChange={handleDisbursementChange} onRemove={removeDisbursement} />
+              ))}
+            </div>
+            <Button onClick={addDisbursement} variant="secondary" className="mt-4 text-sm" type="button">
+              <PlusCircle size={16} className="inline mr-1" /> Add Disbursement Manually
+            </Button>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-700 mb-4">Invoice PDF Mappings</h2>
+            <p className="text-sm text-gray-500 mb-3">Map Payment IDs to their invoice PDFs. Select a PDF for each mapping. Files will be uploaded to Firebase Storage on save.</p>
+            <div className="space-y-4">
+              {invoiceMappings.map((item, index) => (
+                <InvoiceMappingItem key={item._tempId} item={item} index={index} onChange={handleMappingChange} onRemove={removeMapping} availablePaymentIds={availablePaymentIdsForMapping} onFileSelect={handleMappingFileSelect} caseIdForPath={editingCaseId} />
+              ))}
+            </div>
+            <Button onClick={addMapping} variant="secondary" className="mt-4 text-sm" type="button">
+              <PlusCircle size={16} className="inline mr-1" /> Add Mapping
+            </Button>
+          </section>
+
+          <div className="flex justify-end space-x-3 pt-6 border-t border-gray-200">
+            <Button onClick={() => navigate('/admin')} variant="secondary" type="button" disabled={loading} isLoading={loading && !isEditing}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={loading} isLoading={loading}>
+              {isEditing ? 'Save Changes' : 'Create Case'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const DisbursementItem = ({ item, index, onChange, onRemove }) => {
+  const handleChange = (e) => {
+    onChange(index, { ...item, [e.target.name]: e.target.value });
+  };
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-5 gap-3 items-center p-3 border border-gray-200 rounded-md">
+      <Input name="paymentId" value={item.paymentId} onChange={handleChange} placeholder="Payment ID" required />
+      <Input name="payee" value={item.payee} onChange={handleChange} placeholder="Payee" required />
+      <Input name="amount" type="number" value={item.amount} onChange={handleChange} placeholder="Amount (e.g., 123.45)" required />
+      <Input name="paymentDate" type="date" value={item.paymentDate} onChange={handleChange} placeholder="Payment Date" required />
+      <Button onClick={() => onRemove(index)} variant="danger" className="h-10">
+        <Trash2 size={18} />
+      </Button>
+    </div>
+  );
+};
+
+const InvoiceMappingItem = ({ item, index, onChange, onRemove, availablePaymentIds, onFileSelect, caseIdForPath }) => {
+  const fileInputId = `pdfFile-${item._tempId}`;
+
+  const handleFileChange = (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      onFileSelect(index, file);
     }
   };
 
-  if (loading) return <div>Loading...</div>;
-
   return (
-    <form onSubmit={handleSubmit} className="space-y-4 max-w-xl">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 items-start p-3 border border-gray-200 rounded-md">
       <div>
-        <label className="block text-sm font-medium mb-1">Case Name</label>
-        <Input name="caseName" value={form.caseName} onChange={handleChange} required />
+        <label htmlFor={`paymentId-${item._tempId}`} className="block text-xs font-medium text-gray-700">
+          Payment ID
+        </label>
+        <select id={`paymentId-${item._tempId}`} name="paymentId" value={item.paymentId} onChange={(e) => onChange(index, { ...item, paymentId: e.target.value, clientSideFile: item.clientSideFile, fileName: item.fileName, storagePath: item.storagePath, uploadProgress: item.uploadProgress, uploadError: item.uploadError, downloadURL: item.downloadURL })} required className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+          <option value="">Select Payment ID</option>
+          {availablePaymentIds.map((pid) => (
+            <option key={pid} value={pid}>
+              {pid}
+            </option>
+          ))}
+        </select>
       </div>
-      <div>
-        <label className="block text-sm font-medium mb-1">Visible To User IDs (comma separated)</label>
-        <Textarea name="visibleToUserIds" value={form.visibleToUserIds} onChange={handleChange} rows={3} />
+      <div className="flex flex-col">
+        <label htmlFor={fileInputId} className="block text-xs font-medium text-gray-700">
+          Invoice PDF
+        </label>
+        <Input id={fileInputId} type="file" accept=".pdf" onChange={handleFileChange} className="mt-1" />
+        {item.fileName && (
+          <div className="mt-1 text-xs text-gray-600 flex items-center">
+            <Paperclip size={12} className="mr-1 flex-shrink-0" />
+            <span className="truncate" title={item.fileName}>
+              {item.fileName}
+            </span>
+          </div>
+        )}
+        {item.uploadProgress !== undefined && item.uploadProgress >= 0 && item.uploadProgress < 100 && !item.uploadError && (
+          <div className="w-full bg-gray-200 rounded-full h-2.5 mt-2 dark:bg-gray-700">
+            <div className="bg-blue-600 h-2.5 rounded-full text-xs text-white text-center leading-none" style={{ width: `${item.uploadProgress}%` }}>
+              {item.uploadProgress > 10 ? `${Math.round(item.uploadProgress)}%` : ''}
+            </div>
+          </div>
+        )}
+        {item.uploadProgress === 100 && !item.uploadError && (
+          <p className="text-xs text-green-600 mt-1 flex items-center">
+            <CheckCircle2 size={14} className="mr-1" />Uploaded
+          </p>
+        )}
+        {item.uploadError && (
+          <p className="text-xs text-red-500 mt-1 flex items-center">
+            <AlertTriangle size={14} className="mr-1" />{item.uploadError}
+          </p>
+        )}
       </div>
-      <Button type="submit">{caseId ? 'Update Case' : 'Create Case'}</Button>
-    </form>
+      <Button onClick={() => onRemove(index)} variant="danger" className="h-10 self-end">
+        <Trash2 size={18} />
+      </Button>
+    </div>
   );
-}
+};
+

--- a/src/pages/TraineeCaseViewPage.jsx
+++ b/src/pages/TraineeCaseViewPage.jsx
@@ -1,33 +1,207 @@
 import React, { useEffect, useState } from 'react';
-import { doc, getDoc } from 'firebase/firestore';
-import { db, FirestorePaths, Button, useRoute } from '../AppCore';
+import { doc, onSnapshot, setDoc, Timestamp } from 'firebase/firestore';
+import { ref as storageRef, getDownloadURL } from 'firebase/storage';
+import { db, storage, FirestorePaths, Button, useRoute, useAuth, useModal } from '../AppCore';
+import { Send, FileText, Eye } from 'lucide-react';
 
 export default function TraineeCaseViewPage({ params }) {
-  const caseId = params?.caseId;
+  const { caseId } = params;
   const { navigate } = useRoute();
+  const { userId } = useAuth();
+  const { showModal, hideModal } = useModal();
+
   const [caseData, setCaseData] = useState(null);
+  const [selectedDisbursements, setSelectedDisbursements] = useState({});
+  const [submittedDocuments, setSubmittedDocuments] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    async function load() {
-      try {
-        const snap = await getDoc(doc(db, FirestorePaths.CASE_DOCUMENT(caseId)));
-        if (snap.exists()) setCaseData(snap.data());
-      } catch (err) {
-        console.error('Failed to load case', err);
-      }
+    if (!caseId || !userId) {
+      if (!caseId) navigate('/trainee');
       setLoading(false);
+      return;
     }
-    load();
-  }, [caseId]);
+    setLoading(true);
+    const caseRef = doc(db, FirestorePaths.CASE_DOCUMENT(caseId));
+    const unsubscribe = onSnapshot(
+      caseRef,
+      (docSnap) => {
+        if (docSnap.exists() && !docSnap.data()._deleted) {
+          const data = docSnap.data();
+          if (data.visibleToUserIds && data.visibleToUserIds.length > 0 && !data.visibleToUserIds.includes(userId)) {
+            showModal('You do not have permission to view this case.', 'Access Denied');
+            navigate('/trainee');
+            return;
+          }
+          setCaseData({ id: docSnap.id, ...data });
+        } else {
+          showModal('Case not found or has been removed.', 'Error');
+          navigate('/trainee');
+        }
+        setLoading(false);
+      },
+      (error) => {
+        console.error('Error fetching case: ', error);
+        showModal('Error fetching case: ' + error.message, 'Error');
+        setLoading(false);
+        navigate('/trainee');
+      }
+    );
+    return () => unsubscribe();
+  }, [caseId, navigate, userId, showModal]);
 
-  if (loading) return <div>Loading...</div>;
-  if (!caseData) return <div>Case not found.</div>;
+  const handleSelectionChange = (paymentId) => {
+    setSelectedDisbursements((prev) => ({
+      ...prev,
+      [paymentId]: !prev[paymentId],
+    }));
+  };
+
+  const handleSubmitSelections = async () => {
+    if (!caseData || !userId) return;
+    const selectedIds = Object.entries(selectedDisbursements)
+      .filter(([_, isSelected]) => isSelected)
+      .map(([paymentId]) => paymentId);
+
+    if (selectedIds.length === 0) {
+      showModal('Please select at least one disbursement to test.', 'No Selection');
+      return;
+    }
+
+    const documents = [];
+    selectedIds.forEach((pid) => {
+      (caseData.invoiceMappings || []).forEach((mapping) => {
+        if (mapping.paymentId === pid) {
+          documents.push({ fileName: mapping.fileName, storagePath: mapping.storagePath, downloadURL: mapping.downloadURL });
+        }
+      });
+    });
+    setSubmittedDocuments(documents);
+
+    try {
+      const submissionRef = doc(db, FirestorePaths.USER_CASE_SUBMISSION(userId, caseId));
+      await setDoc(
+        submissionRef,
+        {
+          caseId,
+          caseName: caseData.caseName,
+          selectedPaymentIds: selectedIds,
+          retrievedDocuments: documents,
+          submittedAt: Timestamp.now(),
+        },
+        { merge: true }
+      );
+      showModal('Selections submitted. Review your documents below.', 'Submission Successful');
+    } catch (error) {
+      console.error('Error saving submission:', error);
+      showModal('Error saving submission: ' + error.message, 'Error');
+    }
+  };
+
+  const handleViewDocument = async (docInfo) => {
+    if (!docInfo || (!docInfo.storagePath && !docInfo.downloadURL)) {
+      showModal('Document path or URL is missing. Cannot view.', 'Error');
+      return;
+    }
+    if (docInfo.storagePath && docInfo.storagePath.includes('PENDING_CASE_ID')) {
+      showModal('Document is still pending processing by admin (Case ID not finalized for path). Cannot view yet.', 'Error');
+      return;
+    }
+
+    if (docInfo.downloadURL) {
+      window.open(docInfo.downloadURL, '_blank');
+      return;
+    }
+
+    if (docInfo.storagePath) {
+      showModal(`Attempting to get download URL for: ${docInfo.fileName}\nPath: ${docInfo.storagePath}\n\nPlease wait...`, 'Fetching Document', () => null);
+      try {
+        const fileRef = storageRef(storage, docInfo.storagePath);
+        const url = await getDownloadURL(fileRef);
+        hideModal();
+        window.open(url, '_blank');
+      } catch (error) {
+        console.error('Error getting download URL:', error);
+        hideModal();
+        let errorMessage = `Could not retrieve document: ${docInfo.fileName}.\nError: ${error.code}\n\n`;
+        errorMessage += 'This usually means the file was not actually uploaded to Firebase Storage at the expected path by an administrator, or you don\'t have permission to access it.\n\n';
+        errorMessage += `Expected path: ${docInfo.storagePath}\n\n`;
+        errorMessage += 'Please ensure the admin has uploaded the file and that Firebase Storage rules are correctly configured.';
+        showModal(errorMessage, 'Error Viewing Document');
+      }
+    } else {
+      showModal('No valid way to access the document.', 'Error');
+    }
+  };
+
+  const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+
+  if (loading) return <div className="p-4 text-center">Loading case details...</div>;
+  if (!caseData) return <div className="p-4 text-center">Case not found or you may not have access. Redirecting...</div>;
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-lg font-semibold">{caseData.caseName}</h2>
-      <Button variant="secondary" onClick={() => navigate('/trainee/dashboard')}>Back</Button>
+    <div className="p-6 bg-gray-50 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <Button onClick={() => navigate('/trainee')} variant="secondary" className="mb-4 text-sm">
+          &larr; Back to Cases
+        </Button>
+        <div className="bg-white p-8 rounded-lg shadow-xl">
+          <h1 className="text-3xl font-bold text-gray-800 mb-2">{caseData.caseName}</h1>
+          <p className="text-gray-600 mb-6">Select the disbursements you wish to test by checking the boxes below.</p>
+
+          {caseData.disbursements && caseData.disbursements.length > 0 ? (
+            <div className="space-y-3 mb-8">
+              {caseData.disbursements.map((d) => (
+                <div key={d.paymentId} className="flex items-center p-4 border border-gray-200 rounded-md hover:bg-gray-50 transition-colors">
+                  <input type="checkbox" id={`cb-${d.paymentId}`} checked={!!selectedDisbursements[d.paymentId]} onChange={() => handleSelectionChange(d.paymentId)} className="h-5 w-5 text-blue-600 border-gray-300 rounded focus:ring-blue-500 mr-4 cursor-pointer" />
+                  <label htmlFor={`cb-${d.paymentId}`} className="flex-grow grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-1 cursor-pointer">
+                    <span className="text-sm text-gray-700">
+                      <strong className="font-medium">ID:</strong> {d.paymentId}
+                    </span>
+                    <span className="text-sm text-gray-700">
+                      <strong className="font-medium">Payee:</strong> {d.payee}
+                    </span>
+                    <span className="text-sm text-gray-700">
+                      <strong className="font-medium">Amount:</strong> {currencyFormatter.format(parseFloat(d.amount || 0))}
+                    </span>
+                    <span className="text-sm text-gray-700">
+                      <strong className="font-medium">Date:</strong> {d.paymentDate}
+                    </span>
+                  </label>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-gray-500">No disbursements available in this case.</p>
+          )}
+
+          <Button onClick={handleSubmitSelections} disabled={Object.values(selectedDisbursements).every((v) => !v)}>
+            <Send size={18} className="inline mr-2" /> Submit Selections
+          </Button>
+
+          {submittedDocuments !== null && (
+            <div className="mt-10 pt-6 border-t border-gray-200">
+              <h2 className="text-2xl font-semibold text-gray-700 mb-4">Your Selected Documents</h2>
+              {submittedDocuments.length > 0 ? (
+                <ul className="space-y-3">
+                  {submittedDocuments.map((docInfo, index) => (
+                    <li key={index} className="text-gray-700 flex items-center justify-between p-3 bg-gray-50 rounded-md">
+                      <span className="flex items-center">
+                        <FileText size={18} className="text-blue-500 mr-2 flex-shrink-0" /> {docInfo.fileName}
+                      </span>
+                      <Button onClick={() => handleViewDocument(docInfo)} variant="secondary" className="text-xs px-2 py-1">
+                        <Eye size={14} className="inline mr-1" /> View Document
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-gray-500">No documents correspond to your selections based on the current mappings.</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/TraineeDashboardPage.jsx
+++ b/src/pages/TraineeDashboardPage.jsx
@@ -1,36 +1,73 @@
 import React, { useEffect, useState } from 'react';
-import { getFunctions, httpsCallable } from 'firebase/functions';
-import { firebaseApp, Button, useRoute } from '../AppCore';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
+import { db, FirestorePaths, Button, useRoute, useModal, useAuth } from '../AppCore';
+import { ListChecks, BookOpen } from 'lucide-react';
 
 export default function TraineeDashboardPage() {
   const { navigate } = useRoute();
+  const { userId } = useAuth();
+  const { showModal } = useModal();
   const [cases, setCases] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loadingCases, setLoadingCases] = useState(true);
 
   useEffect(() => {
-    const fn = httpsCallable(getFunctions(firebaseApp), 'getMyVisibleCases');
-    fn().then(res => {
-      setCases(res.data.cases || []);
-      setLoading(false);
-    }).catch(err => {
-      console.error('Failed to load cases', err);
-      setLoading(false);
-    });
-  }, []);
+    if (!userId) {
+      setLoadingCases(false);
+      return;
+    }
+    const casesCollectionRef = collection(db, FirestorePaths.CASES_COLLECTION());
+    const q = query(casesCollectionRef, where('_deleted', '!=', true));
 
-  if (loading) return <div>Loading cases...</div>;
+    const unsubscribe = onSnapshot(
+      q,
+      (querySnapshot) => {
+        const casesData = querySnapshot.docs
+          .map((doc) => ({ id: doc.id, ...doc.data() }))
+          .filter((caseDoc) => {
+            return !caseDoc.visibleToUserIds || caseDoc.visibleToUserIds.length === 0 || caseDoc.visibleToUserIds.includes(userId);
+          });
+        setCases(casesData);
+        setLoadingCases(false);
+      },
+      (error) => {
+        console.error('Error fetching cases for trainee: ', error);
+        showModal('Error fetching cases: ' + error.message, 'Error');
+        setLoadingCases(false);
+      }
+    );
+    return () => unsubscribe();
+  }, [userId, showModal]);
+
+  if (loadingCases) return <div className="p-4 text-center">Loading available cases...</div>;
+  if (!userId && !loadingCases) return <div className="p-4 text-center">Authenticating user, please wait...</div>;
 
   return (
-    <div className="space-y-4">
-      {cases.length === 0 && <p>No available cases.</p>}
-      <ul className="space-y-2">
-        {cases.map(c => (
-          <li key={c.id} className="border rounded p-2 flex justify-between">
-            <span>{c.caseName}</span>
-            <Button variant="secondary" onClick={() => navigate(`/trainee/case/${c.id}`)}>Open</Button>
-          </li>
-        ))}
-      </ul>
+    <div className="p-6 bg-gray-50 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-800 mb-8">Available Audit Cases</h1>
+        {cases.length === 0 ? (
+          <div className="text-center py-10 bg-white rounded-lg shadow">
+            <ListChecks size={48} className="mx-auto text-gray-400 mb-4" />
+            <p className="text-gray-600 text-xl">No cases currently assigned or available to you.</p>
+            <p className="text-gray-500 mt-2">Please check back later or contact an administrator.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {cases.map((caseData) => (
+              <div key={caseData.id} className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow flex flex-col justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold text-blue-700 mb-2">{caseData.caseName}</h2>
+                  <p className="text-sm text-gray-600 mb-1">Disbursements: {caseData.disbursements?.length || 0}</p>
+                  <p className="text-sm text-gray-500 mb-4">Created: {caseData.createdAt?.toDate().toLocaleDateString()}</p>
+                </div>
+                <Button onClick={() => navigate(`/trainee/case/${caseData.id}`)} className="w-full mt-auto">
+                  <BookOpen size={18} className="inline mr-2" /> View Case
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve admin dashboard with case info and delete flow
- add admin user management and submission views
- overhaul case form with disbursement CSV import and invoice mappings
- update trainee dashboard and case view with document retrieval

## Testing
- `npm test --silent -- --runTestsByPath src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684c5f0f2d00832d982cfede309696bc