### PR TITLE
feat: enforce firestore rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 On each launch the app shows a role selection screen. No user ID is created until you choose a role, at which point the app signs in anonymously and stores your selection.
 
+## Security Rules Overview
+
+The application relies on Firebase security rules for both Firestore and Storage.
+Admins can read and write all case and user data. Trainees may only read the
+cases they are authorized for and submit their own selections. See
+`firestore.rules` and `storage.rules` for the exact RBAC logic.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,10 +1,54 @@
-// WARNING: Completely open rules – do NOT use in production!
 rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    function getUserRole() {
+      return request.auth != null ?
+        get(/databases/$(database)/documents/roles/$(request.auth.uid)).data.role :
+        null;
+    }
+
+    function isAdmin() {
+      return getUserRole() == 'admin';
+    }
+
+    function isTrainee() {
+      return getUserRole() == 'trainee';
+    }
+
+    function traineeHasAccessToCase(caseId) {
+      return exists(/databases/$(database)/documents/artifacts/$(appId)/cases/$(caseId)/authorizedTrainees/$(request.auth.uid));
+    }
+
+    match /roles/{userId} {
+      allow read, write: if request.auth != null &&
+        (request.auth.uid == userId || isAdmin());
+    }
+
+    match /artifacts/{appId}/public/data/cases/{caseId} {
+      allow read: if request.auth != null && (
+        isAdmin() ||
+        (isTrainee() && traineeHasAccessToCase(caseId))
+      );
+      allow write: if request.auth != null && isAdmin();
+    }
+
+    match /artifacts/{appId}/users/{userId}/userProfileData/profile {
+      allow read: if request.auth != null && (request.auth.uid == userId || isAdmin());
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /artifacts/{appId}/users/{userId}/caseSubmissions/{caseId} {
+      allow read: if request.auth != null && (isAdmin() || request.auth.uid == userId);
+      allow write: if request.auth != null && request.auth.uid == userId && isTrainee();
+    }
+
+    match /artifacts/{appId}/cases/{caseId}/authorizedTrainees/{traineeId} {
+      allow read, write: if request.auth != null && isAdmin();
+    }
+
     match /{document=**} {
-      allow read, write: if true;  // All users can read and write anything
+      allow read, write: if false;
     }
   }
 }


### PR DESCRIPTION
## Summary
- secure Firestore with role-based rules
- document how admin and trainee permissions work

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fa3904b44832da6b15e980f853544