### PR TITLE
feat: centralize firestore logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Admins can read and write all case and user data. Trainees may only read the
 cases they are authorized for and submit their own selections. See
 `firestore.rules` and `storage.rules` for the exact RBAC logic.
 
+## Firebase Service Modules
+
+Firestore queries and mutations are centralized under `src/services/`. Pages
+import these modules (e.g. `caseService.js`, `submissionService.js`) instead of
+calling Firestore directly. This makes page components slimmer and allows tests
+to easily mock Firebase interactions.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/pages/TraineeDashboardPage.jsx
+++ b/src/pages/TraineeDashboardPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { collection, onSnapshot, query, where } from 'firebase/firestore';
-import { db, FirestorePaths, Button, useRoute, useModal, useAuth } from '../AppCore';
+import { Button, useRoute, useModal, useAuth } from '../AppCore';
+import { subscribeToActiveCases } from '../services/caseService';
 import { ListChecks, BookOpen } from 'lucide-react';
 
 export default function TraineeDashboardPage() {
@@ -15,18 +15,13 @@ export default function TraineeDashboardPage() {
       setLoadingCases(false);
       return;
     }
-    const casesCollectionRef = collection(db, FirestorePaths.CASES_COLLECTION());
-    const q = query(casesCollectionRef, where('_deleted', '!=', true));
 
-    const unsubscribe = onSnapshot(
-      q,
-      (querySnapshot) => {
-        const casesData = querySnapshot.docs
-          .map((doc) => ({ id: doc.id, ...doc.data() }))
-          .filter((caseDoc) => {
-            return !caseDoc.visibleToUserIds || caseDoc.visibleToUserIds.length === 0 || caseDoc.visibleToUserIds.includes(userId);
-          });
-        setCases(casesData);
+    const unsubscribe = subscribeToActiveCases(
+      (data) => {
+        const filtered = data.filter(
+          (caseDoc) => !caseDoc.visibleToUserIds || caseDoc.visibleToUserIds.length === 0 || caseDoc.visibleToUserIds.includes(userId)
+        );
+        setCases(filtered);
         setLoadingCases(false);
       },
       (error) => {

--- a/src/services/caseService.js
+++ b/src/services/caseService.js
@@ -1,0 +1,52 @@
+import { collection, doc, getDoc, getDocs, addDoc, setDoc, query, onSnapshot, where, Timestamp } from 'firebase/firestore';
+import { db, FirestorePaths } from '../AppCore';
+
+export const subscribeToCases = (onData, onError) => {
+  const q = query(collection(db, FirestorePaths.CASES_COLLECTION()));
+  return onSnapshot(q, (snap) => {
+    const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    onData(data);
+  }, onError);
+};
+
+export const subscribeToActiveCases = (onData, onError) => {
+  const q = query(collection(db, FirestorePaths.CASES_COLLECTION()), where('_deleted', '!=', true));
+  return onSnapshot(q, (snap) => {
+    const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    onData(data);
+  }, onError);
+};
+
+export const subscribeToCase = (caseId, onData, onError) => {
+  const ref = doc(db, FirestorePaths.CASE_DOCUMENT(caseId));
+  return onSnapshot(ref, (snap) => {
+    if (!snap.exists()) {
+      onData(null);
+    } else {
+      onData({ id: snap.id, ...snap.data() });
+    }
+  }, onError);
+};
+
+export const fetchCase = async (caseId) => {
+  const ref = doc(db, FirestorePaths.CASE_DOCUMENT(caseId));
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  return { id: snap.id, ...snap.data() };
+};
+
+export const createCase = async (data) => {
+  const collectionRef = collection(db, FirestorePaths.CASES_COLLECTION());
+  const docRef = await addDoc(collectionRef, { ...data, createdAt: Timestamp.now(), updatedAt: Timestamp.now() });
+  return docRef.id;
+};
+
+export const updateCase = async (caseId, data) => {
+  const ref = doc(db, FirestorePaths.CASE_DOCUMENT(caseId));
+  await setDoc(ref, { ...data, updatedAt: Timestamp.now() }, { merge: true });
+};
+
+export const markCaseDeleted = async (caseId) => {
+  const ref = doc(db, FirestorePaths.CASE_DOCUMENT(caseId));
+  await setDoc(ref, { _deleted: true, updatedAt: Timestamp.now() }, { merge: true });
+};

--- a/src/services/submissionService.js
+++ b/src/services/submissionService.js
@@ -1,0 +1,22 @@
+import { collection, doc, getDoc, getDocs, setDoc } from 'firebase/firestore';
+import { db, FirestorePaths } from '../AppCore';
+
+export const saveSubmission = async (userId, caseId, data) => {
+  const ref = doc(db, FirestorePaths.USER_CASE_SUBMISSION(userId, caseId));
+  await setDoc(ref, data, { merge: true });
+};
+
+export const fetchSubmissionsForCase = async (caseId) => {
+  const usersRef = collection(db, FirestorePaths.USERS_COLLECTION());
+  const userDocs = await getDocs(usersRef);
+  const submissions = [];
+  for (const userDoc of userDocs.docs) {
+    const userId = userDoc.id;
+    const submissionRef = doc(db, FirestorePaths.USER_CASE_SUBMISSION(userId, caseId));
+    const submissionSnap = await getDoc(submissionRef);
+    if (submissionSnap.exists()) {
+      submissions.push({ id: submissionSnap.id, userId, ...submissionSnap.data() });
+    }
+  }
+  return submissions;
+};


### PR DESCRIPTION
## Summary
- create `caseService` and `submissionService` modules
- refactor pages to use service modules
- document new service layer in README

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685043bc551c832d80a7abc815ae0a61