### PR TITLE
feat: add trainee disbursement classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ The application relies on Firebase security rules for both Firestore and Storage
    summary of a case. Links from this page allow quick access to editing and to
    trainee submissions.
 
+## Trainee Workflow
+
+1. From the Trainee Dashboard select a case to work on.
+2. On the case view page choose which disbursements to test and classify each
+   selected item using the provided options.
+3. Submit your selections to store them with your user record. A confirmation
+   screen summarizes the payment IDs chosen and any retrieved invoice PDFs with
+   links to open them.
+
 ## Firebase Service Modules
 
 Firestore queries and mutations are centralized under `src/services/`. Pages import these modules instead of calling Firestore directly. This keeps page components slimmer and allows tests to easily mock Firebase interactions.

--- a/src/pages/TraineeCaseViewPage.test.jsx
+++ b/src/pages/TraineeCaseViewPage.test.jsx
@@ -12,17 +12,23 @@ jest.mock('../services/submissionService', () => ({
 
 jest.mock('../AppCore', () => ({
   Button: ({ children }) => <button>{children}</button>,
+  Select: (props) => <select {...props} />,
+  CLASSIFICATION_OPTIONS: [
+    { value: '', label: 'Select Classification…', disabled: true },
+    { value: 'Properly Included', label: 'Properly Included' }
+  ],
   useRoute: () => ({ navigate: jest.fn() }),
   useModal: () => ({ showModal: jest.fn(), hideModal: jest.fn() }),
   useAuth: () => ({ userId: 'u1' }),
   storage: {}
 }));
 
-test('renders case view after load', async () => {
+test('renders classification select', async () => {
   subscribeToCase.mockImplementation((id, cb) => {
-    setTimeout(() => cb({ caseName: 'Case', disbursements: [] }), 0);
+    cb({ caseName: 'Case', disbursements: [{ paymentId: 'p1', payee: 'A', amount: '1', paymentDate: '2024-01-01' }] });
     return jest.fn();
   });
   render(<TraineeCaseViewPage params={{ caseId: 'c1' }} />);
   await screen.findByText(/select the disbursements/i);
+  expect(screen.getByRole('combobox')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add new Trainee workflow steps in README
- allow trainees to classify disbursements before submitting
- show confirmation summary after submission
- test that classification select renders

## Testing
- `CI=true npm test -- -u` *(fails: Command killed due to out-of-memory or timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685092c2c324832d83f73537772c4fec