### PR TITLE
feat: add submission detail page and update rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ The application relies on Firebase security rules for both Firestore and Storage
 3. Use the new **Case Overview** page from the dashboard to view a read-only
    summary of a case. Links from this page allow quick access to editing and to
    trainee submissions.
+4. From the submissions list you can drill down into a **Submission Detail** page
+   to review each trainee's selections and classifications. If a trainee has
+   attempted the same case multiple times the detail page shows each attempt
+   chronologically along with any recorded grade.
 
 ## Trainee Workflow
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,7 +22,12 @@ service cloud.firestore {
 
     // Checks if the trainee is allowed to view a case
     function traineeHasAccessToCase(caseId) {
-      return exists(/databases/$(database)/documents/artifacts/$(appId)/cases/$(caseId)/authorizedTrainees/$(request.auth.uid));
+      let caseDoc = get(/databases/$(database)/documents/artifacts/$(appId)/public/data/cases/$(caseId));
+      return caseDoc.exists() && (
+        !(caseDoc.data.visibleToUserIds is list) ||
+        caseDoc.data.visibleToUserIds.size() == 0 ||
+        request.auth.uid in caseDoc.data.visibleToUserIds
+      );
     }
 
     // Role documents store whether a user is an admin or trainee
@@ -52,10 +57,6 @@ service cloud.firestore {
       allow write: if request.auth != null && request.auth.uid == userId && isTrainee();
     }
 
-    // List of trainees allowed to access a case
-    match /artifacts/{appId}/cases/{caseId}/authorizedTrainees/{traineeId} {
-      allow read, write: if request.auth != null && isAdmin();
-    }
 
     // Deny all other access by default
     match /{document=**} {

--- a/src/AppPages.js
+++ b/src/AppPages.js
@@ -23,6 +23,7 @@ import RoleRoute from './routes/RoleRoute';
 import AdminDashboardPage from './pages/AdminDashboardPage';
 import AdminUserManagementPage from './pages/AdminUserManagementPage';
 import AdminCaseSubmissionsPage from './pages/AdminCaseSubmissionsPage';
+import AdminSubmissionDetailPage from './pages/AdminSubmissionDetailPage';
 import AdminCaseOverviewPage from './pages/AdminCaseOverviewPage';
 import CaseFormPage from './pages/CaseFormPage';
 import TraineeDashboardPage from './pages/TraineeDashboardPage';
@@ -94,6 +95,7 @@ const adminRoutes = {
     '/admin/case-overview/:caseId': (params) => <AdminCaseOverviewPage params={params} />,
     '/admin/user-management': <AdminUserManagementPage />,
     '/admin/case-submissions/:caseId': (params) => <AdminCaseSubmissionsPage params={params} />,
+    '/admin/submission-detail/:caseId/:userId': (params) => <AdminSubmissionDetailPage params={params} />,
 };
 
 const traineeRoutes = {
@@ -209,6 +211,7 @@ export {
     AdminDashboardPage,
     AdminUserManagementPage,
     AdminCaseSubmissionsPage,
+    AdminSubmissionDetailPage,
     AdminCaseOverviewPage,
     CaseFormPage,
     TraineeDashboardPage,

--- a/src/pages/AdminCaseSubmissionsPage.jsx
+++ b/src/pages/AdminCaseSubmissionsPage.jsx
@@ -84,6 +84,19 @@ export default function AdminCaseSubmissionsPage({ params }) {
                     <p className="text-sm text-gray-500">None</p>
                   )}
                 </div>
+                {submission.attempts && submission.attempts.length > 1 && (
+                  <p className="text-sm text-gray-500 mt-1">Attempts: {submission.attempts.length}</p>
+                )}
+                {submission.overallGrade !== undefined && (
+                  <p className="text-sm text-gray-700 mt-1">Grade: {submission.overallGrade}</p>
+                )}
+                <Button
+                  onClick={() => navigate(`/admin/submission-detail/${caseId}/${submission.userId}`)}
+                  variant="secondary"
+                  className="mt-4 text-sm"
+                >
+                  View Details
+                </Button>
               </div>
             ))}
           </div>

--- a/src/pages/AdminSubmissionDetailPage.jsx
+++ b/src/pages/AdminSubmissionDetailPage.jsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from 'react';
+import { Button, useRoute, useModal } from '../AppCore';
+import { fetchCase } from '../services/caseService';
+import { fetchSubmission } from '../services/submissionService';
+
+export default function AdminSubmissionDetailPage({ params }) {
+  const { caseId, userId } = params;
+  const { navigate } = useRoute();
+  const { showModal } = useModal();
+  const [caseName, setCaseName] = useState('');
+  const [submission, setSubmission] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!caseId || !userId) {
+      navigate('/admin');
+      return;
+    }
+    setLoading(true);
+    fetchCase(caseId).then((c) => {
+      if (c) setCaseName(c.caseName);
+    });
+    fetchSubmission(userId, caseId)
+      .then((doc) => {
+        setSubmission(doc);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error('Error fetching submission:', err);
+        showModal('Error fetching submission: ' + err.message, 'Error');
+        setLoading(false);
+      });
+  }, [caseId, userId, navigate, showModal]);
+
+  if (loading) return <div className="p-4 text-center">Loading submission...</div>;
+
+  if (!submission) {
+    return (
+      <div className="p-6 bg-gray-50 min-h-screen">
+        <div className="max-w-3xl mx-auto text-center space-y-4">
+          <p>Submission not found.</p>
+          <Button onClick={() => navigate(`/admin/case-submissions/${caseId}`)} variant="secondary">
+            &larr; Back
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const attempts = submission.attempts && submission.attempts.length > 0
+    ? submission.attempts
+    : [{
+        selectedPaymentIds: submission.selectedPaymentIds,
+        disbursementClassifications: submission.disbursementClassifications,
+        submittedAt: submission.submittedAt,
+        overallGrade: submission.overallGrade,
+      }];
+
+  return (
+    <div className="p-6 bg-gray-50 min-h-screen">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex justify-between items-center">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-800 mb-1">Submission Detail</h1>
+            <h2 className="text-lg text-blue-600">{caseName || caseId}</h2>
+            <p className="text-sm text-gray-500">User ID: {userId}</p>
+          </div>
+          <Button onClick={() => navigate(`/admin/case-submissions/${caseId}`)} variant="secondary">
+            &larr; Back
+          </Button>
+        </div>
+        {attempts.map((attempt, idx) => (
+          <div key={idx} className="bg-white p-6 rounded-lg shadow space-y-2">
+            <h3 className="font-semibold text-gray-700">Attempt {idx + 1}</h3>
+            <p className="text-sm text-gray-500">
+              Submitted: {attempt.submittedAt?.toDate ? attempt.submittedAt.toDate().toLocaleString() : 'N/A'}
+            </p>
+            <div>
+              <p className="text-sm font-medium text-gray-600">Selections &amp; Classifications:</p>
+              {attempt.selectedPaymentIds && attempt.selectedPaymentIds.length > 0 ? (
+                <ul className="list-disc list-inside text-sm text-gray-700">
+                  {attempt.selectedPaymentIds.map((pid) => (
+                    <li key={pid} className="break-all">
+                      {pid}
+                      {attempt.disbursementClassifications && attempt.disbursementClassifications[pid]
+                        ? ` — ${attempt.disbursementClassifications[pid]}`
+                        : ''}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-gray-500">None</p>
+              )}
+            </div>
+            {attempt.overallGrade !== undefined && (
+              <p className="text-sm font-medium text-gray-700">Grade: {attempt.overallGrade}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AdminSubmissionDetailPage.test.jsx
+++ b/src/pages/AdminSubmissionDetailPage.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import AdminSubmissionDetailPage from './AdminSubmissionDetailPage';
+import { fetchCase } from '../services/caseService';
+import { fetchSubmission } from '../services/submissionService';
+
+jest.mock('../services/caseService', () => ({
+  fetchCase: jest.fn(),
+}));
+jest.mock('../services/submissionService', () => ({
+  fetchSubmission: jest.fn(),
+}));
+
+jest.mock('../AppCore', () => ({
+  Button: ({ children }) => <button>{children}</button>,
+  useRoute: () => ({ navigate: jest.fn() }),
+  useModal: () => ({ showModal: jest.fn() }),
+}));
+
+test('renders submission detail heading', async () => {
+  fetchCase.mockResolvedValue({ caseName: 'Case A' });
+  fetchSubmission.mockResolvedValue({ selectedPaymentIds: [], attempts: [] });
+  render(<AdminSubmissionDetailPage params={{ caseId: 'c1', userId: 'u1' }} />);
+  expect(await screen.findByText('Submission Detail')).toBeInTheDocument();
+});

--- a/src/services/submissionService.js
+++ b/src/services/submissionService.js
@@ -1,9 +1,32 @@
-import { collection, doc, getDoc, getDocs, setDoc } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  serverTimestamp,
+  arrayUnion,
+} from 'firebase/firestore';
 import { db, FirestorePaths } from '../AppCore';
 
 export const saveSubmission = async (userId, caseId, data) => {
   const ref = doc(db, FirestorePaths.USER_CASE_SUBMISSION(userId, caseId));
-  await setDoc(ref, data, { merge: true });
+  const attemptData = { ...data, submittedAt: serverTimestamp() };
+  await setDoc(
+    ref,
+    {
+      ...data,
+      submittedAt: serverTimestamp(),
+      attempts: arrayUnion(attemptData),
+    },
+    { merge: true }
+  );
+};
+
+export const fetchSubmission = async (userId, caseId) => {
+  const ref = doc(db, FirestorePaths.USER_CASE_SUBMISSION(userId, caseId));
+  const snap = await getDoc(ref);
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 };
 
 export const fetchSubmissionsForCase = async (caseId) => {

--- a/src/services/submissionService.test.js
+++ b/src/services/submissionService.test.js
@@ -1,5 +1,5 @@
-import { saveSubmission, fetchSubmissionsForCase } from './submissionService';
-import { doc, setDoc, getDoc, getDocs, collection } from 'firebase/firestore';
+import { saveSubmission, fetchSubmissionsForCase, fetchSubmission } from './submissionService';
+import { doc, setDoc, getDoc, getDocs, collection, serverTimestamp, arrayUnion } from 'firebase/firestore';
 import { FirestorePaths, db } from '../AppCore';
 
 jest.mock('firebase/firestore', () => ({
@@ -8,6 +8,8 @@ jest.mock('firebase/firestore', () => ({
   getDoc: jest.fn(),
   getDocs: jest.fn(),
   collection: jest.fn(),
+  serverTimestamp: jest.fn(() => 'now'),
+  arrayUnion: jest.fn((v) => v),
 }));
 
 jest.mock('../AppCore', () => ({
@@ -35,5 +37,12 @@ describe('submissionService', () => {
     const result = await fetchSubmissionsForCase('c1');
     expect(collection).toHaveBeenCalled();
     expect(result[0].userId).toBe('u1');
+  });
+
+  test('fetchSubmission returns single submission', async () => {
+    getDoc.mockResolvedValue({ exists: () => true, id: 'sub', data: () => ({ a: 1 }) });
+    const result = await fetchSubmission('u1', 'c1');
+    expect(doc).toHaveBeenCalled();
+    expect(result.id).toBe('sub');
   });
 });


### PR DESCRIPTION
## Summary
- add `AdminSubmissionDetailPage` for reviewing individual trainee attempts
- update `AdminCaseSubmissionsPage` with links to detail page and show attempt/grade info
- support attempt history in `submissionService`
- add tests for new page and service
- update Firestore rules to use `visibleToUserIds`
- document new workflow in README

## Testing
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6850d6d3f124832db1025c48534d07e1