### PR TITLE
fix: validate firebase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ AuditSim Pro is a React and Firebase based training app for simulating audit pro
    cp .env.example .env
    # then edit .env with your values
    ```
-   `REACT_APP_FIREBASE_CONFIG` contains your Firebase configuration JSON and `REACT_APP_APP_ID` identifies the dataset in Firestore. Keep `.env` out of version control.
+   `REACT_APP_FIREBASE_CONFIG` contains your Firebase configuration JSON and `REACT_APP_APP_ID` identifies the dataset in Firestore.
+   Make sure the JSON string in `REACT_APP_FIREBASE_CONFIG` uses **your real Firebase credentials** and does not contain the `<apiKey>` placeholder. Keep `.env` out of version control.
 
 ### Firebase Emulators
 

--- a/src/AppCore.js
+++ b/src/AppCore.js
@@ -34,7 +34,16 @@ if (!window.__initial_auth_token) {
 // ---------- Firebase Initialization ----------
 const firebaseConfigString =
   typeof __firebase_config !== 'undefined' ? __firebase_config : window.__firebase_config;
-const firebaseConfig = JSON.parse(firebaseConfigString);
+let firebaseConfig;
+try {
+  firebaseConfig = JSON.parse(firebaseConfigString);
+} catch (err) {
+  console.error('Invalid Firebase config JSON. Check REACT_APP_FIREBASE_CONFIG in your .env file.');
+  throw err;
+}
+if (!firebaseConfig.apiKey || /<apiKey>/i.test(firebaseConfig.apiKey)) {
+  throw new Error('Missing or invalid Firebase API key. Ensure .env contains your project\'s credentials.');
+}
 const appId = typeof __app_id !== 'undefined' ? __app_id : window.__app_id;
 
 const firebaseApp = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- validate firebase config before initializing Firebase
- clarify README on using real Firebase credentials

## Testing
- `CI=true npm test --silent src/services/caseService.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6850dd829dd4832dbb9b5eebc1e388ff