### PR TITLE
fix: correct firestore rule parameter

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,7 +21,7 @@ service cloud.firestore {
     }
 
     // Checks if the trainee is allowed to view a case
-    function traineeHasAccessToCase(caseId) {
+    function traineeHasAccessToCase(appId, caseId) {
       let caseDoc = get(/databases/$(database)/documents/artifacts/$(appId)/public/data/cases/$(caseId));
       return caseDoc.exists() && (
         !(caseDoc.data.visibleToUserIds is list) ||
@@ -40,7 +40,7 @@ service cloud.firestore {
     match /artifacts/{appId}/public/data/cases/{caseId} {
       allow read: if request.auth != null && (
         isAdmin() ||
-        (isTrainee() && traineeHasAccessToCase(caseId))
+        (isTrainee() && traineeHasAccessToCase(appId, caseId))
       );
       allow write: if request.auth != null && isAdmin();
     }


### PR DESCRIPTION
## Summary
- fix Firestore rules so trainee access helper receives `appId`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b1e05d800832db5ab54a2fd620bee