### PR TITLE
fix: fallback to role doc in security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -6,12 +6,18 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     // Check user role from custom claims
+    function getRole() {
+      return get(/databases/$(database)/documents/roles/$(request.auth.uid)).data.role;
+    }
+
     function isAdmin() {
-      return request.auth != null && request.auth.token.role == 'admin';
+      return request.auth != null &&
+             (request.auth.token.role == 'admin' || getRole() == 'admin');
     }
 
     function isTrainee() {
-      return request.auth != null && request.auth.token.role == 'trainee';
+      return request.auth != null &&
+             (request.auth.token.role == 'trainee' || getRole() == 'trainee');
     }
 
     // Checks if the trainee can view the case currently being read

--- a/storage.rules
+++ b/storage.rules
@@ -5,12 +5,17 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
 
-    // Check user role from custom claims
+    // Check user role from custom claims or fallback role document
+    function getRole() {
+      return get(/databases/$(database)/documents/roles/$(request.auth.uid)).data.role;
+    }
     function isAdmin() {
-      return request.auth != null && request.auth.token.role == 'admin';
+      return request.auth != null &&
+             (request.auth.token.role == 'admin' || getRole() == 'admin');
     }
     function isTrainee() {
-      return request.auth != null && request.auth.token.role == 'trainee';
+      return request.auth != null &&
+             (request.auth.token.role == 'trainee' || getRole() == 'trainee');
     }
 
     // Verifies the trainee has access to the specified case by checking the Firestore case document


### PR DESCRIPTION
## Summary
- allow security rules to check role documents when custom claims are missing

## Testing
- `CI=true npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685c2a7cad58832dbdc16f4358e23941